### PR TITLE
Migrate from autopep8-wrapper to mirrors-autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,29 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.4.0-1
+    rev: v2.0.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
-    -   id: autopep8-wrapper
     -   id: check-docstring-first
     -   id: check-yaml
     -   id: debug-statements
     -   id: flake8
+-   repo: https://github.com/pre-commit/mirrors-autopep8
+    rev: v1.4
+    hooks:
+    -   id: autopep8
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.2.0
+    rev: v1.3.0
     hooks:
     -   id: reorder-python-imports
         args: [--py3-plus]
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v0.7.0
+    rev: v0.7.1
     hooks:
     -   id: add-trailing-comma
         args: [--py36-plus]
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.6.1
+    rev: v1.8.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos