### PR TITLE
Add `python-type-checking-without-pragma` Hook.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,6 +10,12 @@
     entry: '\.warn\('
     language: pygrep
     types: [python]
+-   id: python-type-checking-without-pragma
+    name: Check TYPE_CHECKING without pragma
+    description: 'Enforce that type check imports always occur with pragma no cover annotation to avoid unnecessary code coverage drops.'
+    entry: 'if TYPE_CHECKING:(?!  # pragma: no cover)'
+    language: pygrep
+    types: [python]
 -   id: python-use-type-annotations
     name: type annotations not comments
     description: 'Enforce that python3.6+ type annotations are used instead of type comments'

--- a/README.md
+++ b/README.md
@@ -26,5 +26,6 @@ For example, a hook which targest python will be called `python-...`.
 [generated]: # (generated)
 - **`python-check-mock-methods`**: Prevent a common mistake of `assert mck.not_called()` or `assert mck.called_once_with(...)`
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
+- **`python-type-checking-without-pragma`**: Enforce that type check imports always occur with pragma no cover annotation to avoid unnecessary code coverage drops.
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments
 - **`rst-backticks`**: Detect common mistake of using single backticks when writing rst

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -33,3 +33,24 @@ def test_python_use_type_annotations_positive(s):
 )
 def test_python_use_type_annotations_negative(s):
     assert not HOOKS['python-use-type-annotations'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'if TYPE_CHECKING:',
+    )
+)
+def test_python_pragma_no_cover_positive(s):
+    assert HOOKS['python-type-checking-without-pragma'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'x = 1',
+        'if TYPE_CHECKING:  # pragma: no cover',
+    )
+)
+def test_python_pragma_no_cover_negative(s):
+    assert not HOOKS['python-type-checking-without-pragma'].search(s)


### PR DESCRIPTION
Following are the code coverages on a repo with ~24k lines of Python code:
- Without `# pragma: no cover`: `90.54%`
- With `# pragma: no cover`: `91.73%`