### PR TITLE
python-check-mock-methods: flag missing calls

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 -   id: python-check-mock-methods
     name: check for not-real mock methods
     description: >-
-        Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and
+        Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)`
         and `mck.assert_called`.
     language: pygrep
     entry: >

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,12 +13,8 @@
     entry: >
         (?x)(
             assert .*\.(
-                any_call|
-                called_once|
-                called_once_with|
-                called_with|
-                has_calls|
-                not_called
+                not_called|
+                called_
             )|
             \.assert_(
                 any_call|

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 -   id: python-check-mock-methods
     name: check for not-real mock methods
     description: >
-        Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and 
+        Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and
         and `mck.assert_called`.
     language: pygrep
     entry: '(assert .*\.(not_called|called_)|\.assert_(not_called|called\w*)($|[^(]))'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,9 +6,11 @@
     types: [python]
 -   id: python-check-mock-methods
     name: check for not-real mock methods
-    description: 'Prevent a common mistake of `assert mck.not_called()` or `assert mck.called_once_with(...)`'
+    description: >
+        Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and 
+        and `mck.assert_called`.
     language: pygrep
-    entry: 'assert .*\.(not_called|called_)'
+    entry: '(assert .*\.(not_called|called_)|\.assert_(not_called|called\w*)($|[^(]))'
     types: [python]
 -   id: python-no-log-warn
     name: use logger.warning(

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,7 +6,7 @@
     types: [python]
 -   id: python-check-mock-methods
     name: check for not-real mock methods
-    description: >
+    description: >-
         Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and
         and `mck.assert_called`.
     language: pygrep

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,7 +10,27 @@
         Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and
         and `mck.assert_called`.
     language: pygrep
-    entry: '(assert .*\.(not_called|called_)|\.assert_(not_called|called|called_\w+)($|[^(\w]))'
+    entry: >
+      (?x)(
+        assert .*\.(
+          any_call
+          |called_once
+          |called_once_with
+          |called_with
+          |has_calls
+          |not_called
+        )
+        |
+        \.assert_(
+          any_call
+          |called
+          |called_once
+          |called_once_with
+          |called_with
+          |has_calls
+          |not_called
+        )($|\s)
+      )
     types: [python]
 -   id: python-no-log-warn
     name: use logger.warning(

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,7 +10,7 @@
         Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and
         and `mck.assert_called`.
     language: pygrep
-    entry: '(assert .*\.(not_called|called_)|\.assert_(not_called|called\w*)($|[^(]))'
+    entry: '(assert .*\.(not_called|called\w*)|\.assert_(not_called|called\w*)($|[^(\w]))'
     types: [python]
 -   id: python-no-log-warn
     name: use logger.warning(

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,7 +10,7 @@
         Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and
         and `mck.assert_called`.
     language: pygrep
-    entry: '(assert .*\.(not_called|called\w*)|\.assert_(not_called|called\w*)($|[^(\w]))'
+    entry: '(assert .*\.(not_called|called_)|\.assert_(not_called|called|called_\w+)($|[^(\w]))'
     types: [python]
 -   id: python-no-log-warn
     name: use logger.warning(

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -11,26 +11,25 @@
         and `mck.assert_called`.
     language: pygrep
     entry: >
-      (?x)(
-        assert .*\.(
-          any_call
-          |called_once
-          |called_once_with
-          |called_with
-          |has_calls
-          |not_called
+        (?x)(
+            assert .*\.(
+                any_call|
+                called_once|
+                called_once_with|
+                called_with|
+                has_calls|
+                not_called
+            )|
+            \.assert_(
+                any_call|
+                called|
+                called_once|
+                called_once_with|
+                called_with|
+                has_calls|
+                not_called
+            )($|[^(\w])
         )
-        |
-        \.assert_(
-          any_call
-          |called
-          |called_once
-          |called_once_with
-          |called_with
-          |has_calls
-          |not_called
-        )($|\s)
-      )
     types: [python]
 -   id: python-no-log-warn
     name: use logger.warning(

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ For example, a hook which targest python will be called `python-...`.
 
 [generated]: # (generated)
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes
-- **`python-check-mock-methods`**: Prevent a common mistake of `assert mck.not_called()` or `assert mck.called_once_with(...)`
+- **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and and `mck.assert_called`.
+
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments
 - **`rst-backticks`**: Detect common mistake of using single backticks when writing rst

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ For example, a hook which targest python will be called `python-...`.
 [generated]: # (generated)
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and and `mck.assert_called`.
-
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments
 - **`rst-backticks`**: Detect common mistake of using single backticks when writing rst

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For example, a hook which targest python will be called `python-...`.
 
 [generated]: # (generated)
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes
-- **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and and `mck.assert_called`.
+- **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments
 - **`rst-backticks`**: Detect common mistake of using single backticks when writing rst

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -17,7 +17,7 @@ HOOKS = {h['id']: re.compile(h['entry']) for h in load_manifest(MANIFEST_FILE)}
     ),
 )
 def test_python_use_type_annotations_positive(s):
-    assert HOOKS['python-use-type-annotations'].search(s)
+    assert HOOKS['python-use-type-annotations'].search(s) is not None
 
 
 @pytest.mark.parametrize(
@@ -32,7 +32,7 @@ def test_python_use_type_annotations_positive(s):
     ),
 )
 def test_python_use_type_annotations_negative(s):
-    assert not HOOKS['python-use-type-annotations'].search(s)
+    assert not HOOKS['python-use-type-annotations'].search(s) is not None
 
 
 @pytest.mark.parametrize(
@@ -44,7 +44,7 @@ def test_python_use_type_annotations_negative(s):
     ),
 )
 def test_python_check_blanket_noqa_positive(s):
-    assert HOOKS['python-check-blanket-noqa'].search(s)
+    assert HOOKS['python-check-blanket-noqa'].search(s) is not None
 
 
 @pytest.mark.parametrize(
@@ -56,7 +56,7 @@ def test_python_check_blanket_noqa_positive(s):
     ),
 )
 def test_python_check_blanket_noqa_negative(s):
-    assert not HOOKS['python-check-blanket-noqa'].search(s)
+    assert HOOKS['python-check-blanket-noqa'].search(s) is None
 
 
 @pytest.mark.parametrize(
@@ -70,7 +70,7 @@ def test_python_check_blanket_noqa_negative(s):
     ),
 )
 def test_python_check_mock_methods_positive(s):
-    assert HOOKS['python-check-mock-methods'].search(s)
+    assert HOOKS['python-check-mock-methods'].search(s) is not None
 
 
 @pytest.mark.parametrize(
@@ -84,4 +84,4 @@ def test_python_check_mock_methods_positive(s):
     ),
 )
 def test_python_check_mock_methods_negative(s):
-    assert not HOOKS['python-check-mock-methods'].search(s)
+    assert HOOKS['python-check-mock-methods'].search(s) is None

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -63,7 +63,6 @@ def test_python_check_blanket_noqa_negative(s):
     's',
     (
         'assert my_mock.not_called()',
-        'assert my_mock.called()',
         'assert my_mock.called_once_with()',
         'my_mock.assert_not_called',
         'my_mock.assert_called',
@@ -78,6 +77,7 @@ def test_python_check_mock_methods_positive(s):
     's',
     (
         'assert my_mock.call_count == 1',
+        'assert my_mock.called',
         'my_mock.assert_not_called()',
         'my_mock.assert_called()',
         'my_mock.assert_called_once_with()',

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -67,6 +67,7 @@ def test_python_check_blanket_noqa_negative(s):
         'my_mock.assert_not_called',
         'my_mock.assert_called',
         'my_mock.assert_called_once_with',
+        'my_mock.assert_called_once_with# noqa',
     ),
 )
 def test_python_check_mock_methods_positive(s):

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -57,3 +57,31 @@ def test_python_check_blanket_noqa_positive(s):
 )
 def test_python_check_blanket_noqa_negative(s):
     assert not HOOKS['python-check-blanket-noqa'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'assert my_mock.not_called()',
+        'assert my_mock.called()',
+        'assert my_mock.called_once_with()',
+        'my_mock.assert_not_called',
+        'my_mock.assert_called',
+        'my_mock.assert_called_once_with',
+    ),
+)
+def test_python_check_mock_methods_positive(s):
+    assert HOOKS['python-check-mock-methods'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'assert my_mock.call_count == 1',
+        'my_mock.assert_not_called()',
+        'my_mock.assert_called()',
+        'my_mock.assert_called_once_with()',
+    ),
+)
+def test_python_check_mock_methods_negative(s):
+    assert not HOOKS['python-check-mock-methods'].search(s)

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -17,7 +17,7 @@ HOOKS = {h['id']: re.compile(h['entry']) for h in load_manifest(MANIFEST_FILE)}
     ),
 )
 def test_python_use_type_annotations_positive(s):
-    assert HOOKS['python-use-type-annotations'].search(s) is not None
+    assert HOOKS['python-use-type-annotations'].search(s)
 
 
 @pytest.mark.parametrize(
@@ -32,7 +32,7 @@ def test_python_use_type_annotations_positive(s):
     ),
 )
 def test_python_use_type_annotations_negative(s):
-    assert not HOOKS['python-use-type-annotations'].search(s) is not None
+    assert not HOOKS['python-use-type-annotations'].search(s)
 
 
 @pytest.mark.parametrize(
@@ -44,7 +44,7 @@ def test_python_use_type_annotations_negative(s):
     ),
 )
 def test_python_check_blanket_noqa_positive(s):
-    assert HOOKS['python-check-blanket-noqa'].search(s) is not None
+    assert HOOKS['python-check-blanket-noqa'].search(s)
 
 
 @pytest.mark.parametrize(
@@ -56,7 +56,7 @@ def test_python_check_blanket_noqa_positive(s):
     ),
 )
 def test_python_check_blanket_noqa_negative(s):
-    assert HOOKS['python-check-blanket-noqa'].search(s) is None
+    assert not HOOKS['python-check-blanket-noqa'].search(s)
 
 
 @pytest.mark.parametrize(
@@ -70,7 +70,7 @@ def test_python_check_blanket_noqa_negative(s):
     ),
 )
 def test_python_check_mock_methods_positive(s):
-    assert HOOKS['python-check-mock-methods'].search(s) is not None
+    assert HOOKS['python-check-mock-methods'].search(s)
 
 
 @pytest.mark.parametrize(
@@ -84,4 +84,4 @@ def test_python_check_mock_methods_positive(s):
     ),
 )
 def test_python_check_mock_methods_negative(s):
-    assert HOOKS['python-check-mock-methods'].search(s) is None
+    assert not HOOKS['python-check-mock-methods'].search(s)


### PR DESCRIPTION
Flag non-assertions due to missing call, e.g.
```py
my_mock.assert_called
```