### PR TITLE
change warn pattern to ignore warnings.warn

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,11 +2,12 @@ repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
     -   id: check-docstring-first
     -   id: check-yaml
     -   id: debug-statements
+    -   id: double-quote-string-fixer
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.7
     hooks:

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -36,7 +36,7 @@
 -   id: python-no-log-warn
     name: use logger.warning(
     description: 'A quick check for the deprecated `.warn()` method of python loggers'
-    entry: '\.warn\('
+    entry: '(?<!warnings)\.warn\('
     language: pygrep
     types: [python]
 -   id: python-use-type-annotations

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -99,7 +99,7 @@ def test_python_noeval_negative():
 @pytest.mark.parametrize(
     "s",
     (
-        'log.warn("this is depreciated")',
+        'log.warn("this is deprecated")',
     ),
 )
 def test_python_no_log_warn_positive(s):

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -97,23 +97,23 @@ def test_python_noeval_negative():
 
 
 @pytest.mark.parametrize(
-    "s",
+    's',
     (
         'log.warn("this is deprecated")',
     ),
 )
 def test_python_no_log_warn_positive(s):
-    assert HOOKS["python-no-log-warn"].search(s)
+    assert HOOKS['python-no-log-warn'].search(s)
 
 
 @pytest.mark.parametrize(
-    "s",
+    's',
     (
         "warnings.warn('this is ok')",
         'log.warning("this is ok")',
-        "from warnings import warn",
+        'from warnings import warn',
         'warn("by itself is also ok")',
     ),
 )
 def test_python_no_log_warn_negative(s):
-    assert not HOOKS["python-no-log-warn"].search(s)
+    assert not HOOKS['python-no-log-warn'].search(s)

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -100,7 +100,6 @@ def test_python_noeval_negative():
     "s",
     (
         'log.warn("this is depreciated")',
-        '.warn(this will also be caught',
     ),
 )
 def test_python_no_log_warn_positive(s):

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -99,9 +99,8 @@ def test_python_noeval_negative():
 @pytest.mark.parametrize(
     "s",
     (
-        'log.warn("help")',
-        'logger.warn("well warn dresses found")',
-        'logging.warn("to be or not to be")',
+        'log.warn("this is depreciated")',
+        '.warn(this will also be caught',
     ),
 )
 def test_python_no_log_warn_positive(s):
@@ -111,14 +110,10 @@ def test_python_no_log_warn_positive(s):
 @pytest.mark.parametrize(
     "s",
     (
-        "warnings.warn()",
+        "warnings.warn('this is ok')",
         'log.warning("this is ok")',
-        'warnings.warn("bee be bad")',
-        'print("if warn is just somewhere random")',
-        'warn("test from warnings import warn")',
-        "xx1234warning0394warn",
         "from warnings import warn",
-        "this does not have a trigger word",
+        'warn("by itself is also ok")',
     ),
 )
 def test_python_no_log_warn_negative(s):

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -94,3 +94,32 @@ def test_python_noeval_positive():
 
 def test_python_noeval_negative():
     assert not HOOKS['python-no-eval'].search('literal_eval("{1: 2}")')
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        'log.warn("help")',
+        'logger.warn("well warn dresses found")',
+        'logging.warn("to be or not to be")',
+    ),
+)
+def test_python_no_log_warn_positive(s):
+    assert HOOKS["python-no-log-warn"].search(s)
+
+
+@pytest.mark.parametrize(
+    "s",
+    (
+        "warnings.warn()",
+        'log.warning("this is ok")',
+        'warnings.warn("bee be bad")',
+        'print("if warn is just somewhere random")',
+        'warn("test from warnings import warn")',
+        "xx1234warning0394warn",
+        "from warnings import warn",
+        "this does not have a trigger word",
+    ),
+)
+def test_python_no_log_warn_negative(s):
+    assert not HOOKS["python-no-log-warn"].search(s)


### PR DESCRIPTION
* updated the `python-no-log-warn` search pattern to ignore `warnings.warn(`
* added tests for `python-no-log-warn`