### PR TITLE
rst-backticks: Also find single chars with single backticks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -50,7 +50,7 @@
 -   id: rst-backticks
     name: rst ``code`` is two backticks
     description: 'Detect common mistake of using single backticks when writing rst'
-    entry: '(^| )`[^`]+[^_]`([^_]|$)'
+    entry: '(^| )`[^`]+`([^_]|$)'
     language: pygrep
     types: [rst]
 -   id: text-unicode-replacement-char

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -130,6 +130,7 @@ def test_python_no_log_warn_negative(s):
     (
         '`[code]`',
         'i like `_kitty`',
+        'i like `_`',
     ),
 )
 def test_python_rst_backticks_positive(s):
@@ -141,7 +142,6 @@ def test_python_rst_backticks_positive(s):
     (
         ' ``[code]``',
         'i like _`kitty`',
-        'i like `_`',
         'i like `kitty`_',
     ),
 )

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -131,6 +131,8 @@ def test_python_no_log_warn_negative(s):
         '`[code]`',
         'i like `_kitty`',
         'i like `_`',
+        '`a`',
+        '`cd`',
     ),
 )
 def test_python_rst_backticks_positive(s):
@@ -143,6 +145,8 @@ def test_python_rst_backticks_positive(s):
         ' ``[code]``',
         'i like _`kitty`',
         'i like `kitty`_',
+        '``b``',
+        '``ef``',
     ),
 )
 def test_python_rst_backticks_negative(s):


### PR DESCRIPTION
Is there a particular reason why single characters inside single backticks are skipped by the `rst-backticks` hook?

I don't see any special case at https://docutils.sourceforge.io/docs/user/rst/quickref.html#inline-markup

I'm finding the hook is missing some things which I think it should find.

For example, putting this RST:

```rst

Single character in single backticks:

`a`

Single character in double backticks:

``b``

Two characters in single backticks:

`cd`

Two characters in double backticks:

``ef``
```
through Sphinx I get:

![image](https://user-images.githubusercontent.com/1324225/89576604-2ba19780-d838-11ea-9507-8ef208d543e5.png)

So it'd be nice to also flag single chars with single backticks.

Thanks!