### PR TITLE
RST: Add hook to find inline code touching normal text

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -53,6 +53,12 @@
     entry: '(^| )`[^`]+`([^_]|$)'
     language: pygrep
     types: [rst]
+-   id: rst-inline-touching-normal
+    name: rst ``inline code`` next to normal text
+    description: 'Detect mistake of inline code touching normal text in rst'
+    entry: '\w``\w'
+    language: pygrep
+    types: [rst]
 -   id: text-unicode-replacement-char
     name: no unicode replacement chars
     description: 'Forbid files which have a UTF-8 Unicode replacement character'

--- a/README.md
+++ b/README.md
@@ -30,4 +30,5 @@ For example, a hook which targets python will be called `python-...`.
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments
 - **`rst-backticks`**: Detect common mistake of using single backticks when writing rst
+- **`rst-inline-touching-normal`**: Detect mistake of inline code touching normal text in rst
 - **`text-unicode-replacement-char`**: Forbid files which have a UTF-8 Unicode replacement character

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -156,6 +156,44 @@ def test_python_rst_backticks_negative(s):
 @pytest.mark.parametrize(
     's',
     (
+        '``PyMem_Realloc()`` indirectly call``PyObject_Malloc()`` and',
+        'This PEP proposes that ``bytes`` and ``bytearray``gain an optimised',
+        'Reading this we first see the``break``, which obviously applies to',
+        'for using``long_description`` and a corresponding',
+        '``inline`` normal``inline',
+        '``inline``normal ``inline',
+        '``inline``normal',
+        '``inline``normal``inline',
+        'normal ``inline``normal',
+        'normal``inline`` normal',
+        'normal``inline``',
+        'normal``inline``normal',
+    ),
+)
+def test_python_rst_inline_touching_normal_positive(s):
+    assert HOOKS['rst-inline-touching-normal'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        '``PyMem_Realloc()`` indirectly call ``PyObject_Malloc()`` and',
+        'This PEP proposes that ``bytes`` and ``bytearray`` gain an optimised',
+        'Reading this we first see the ``break``, which obviously applies to',
+        'for using ``long_description`` and a corresponding',
+        '``inline`` normal ``inline',
+        '``inline`` normal',
+        'normal ``inline`` normal',
+        'normal ``inline``',
+    ),
+)
+def test_python_rst_inline_touching_normal_negative(s):
+    assert not HOOKS['rst-inline-touching-normal'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
         str(b'\x80abc', errors='replace'),
     ),
 )


### PR DESCRIPTION
I recently used `rst-backticks` to find and fix some PEPs (https://github.com/python/peps/pull/1554) and am planning to add it as a pre-commit linter on the CI.

I also fixed some related RST problems (https://github.com/python/peps/pull/1560) where inline code touches normal text. This sort of stuff is allowed in Markdown but not reStructuredText:

```diff
-``PyMem_Realloc()`` indirectly call``PyObject_Malloc()`` and
+``PyMem_Realloc()`` indirectly call ``PyObject_Malloc()`` and

-This PEP proposes that ``bytes`` and ``bytearray``gain an optimised
+This PEP proposes that ``bytes`` and ``bytearray`` gain an optimised

-Reading this we first see the``break``, which obviously applies to
+Reading this we first see the ``break``, which obviously applies to

-for using``long_description`` and a corresponding
+for using ``long_description`` and a corresponding
```

Guido suggested a linter for this too (https://github.com/python/peps/pull/1560#pullrequestreview-466007278), and as I used grep to find these:

```
$ git grep "[A-Za-z0-9]\`\`[A-Za-z0-9]"
pep-0445.txt:``PyMem_Realloc()`` indirectly call``PyObject_Malloc()`` and
pep-0467.txt:This PEP proposes that ``bytes`` and ``bytearray``gain an optimised
pep-0548.rst:Reading this we first see the``break``, which obviously applies to
pep-0621.rst:for using``long_description`` and a corresponding
```

then `pygrep-hooks` makes a good fit!

I didn't find anything in the spec where "alphanumeric double-backticks alphanumeric" is allowed so I think it's safe to add:

* https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#inline-markup-recognition-rules

---

Naming things: always hard, feedback welcome for improvements on `rst-inline-touching-normal`.

Tests: I added the four real problems I found in the PEPs, plus some simplified versions. Let me know if you'd prefer only the simplified versions.