### PR TITLE
Allow '# types' comment

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -44,7 +44,7 @@
 -   id: python-use-type-annotations
     name: type annotations not comments
     description: 'Enforce that python3.6+ type annotations are used instead of type comments'
-    entry: '# type(?!: *ignore([^a-zA-Z0-9]|$))'
+    entry: '# type(?!: *ignore([^a-zA-Z0-9]|$))(?!\w)'
     language: pygrep
     types: [python]
 -   id: rst-backticks

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -31,6 +31,7 @@ def test_python_use_type_annotations_positive(s):
         'x = 1  # type: ignore  # noqa',
         'x = 1  # type: ignore[type-mismatch]',
         'x = 1  # type: ignore=E123',
+        '# types of vectorized key functions',
     ),
 )
 def test_python_use_type_annotations_negative(s):


### PR DESCRIPTION
Something I noticed while porting some checks over to pre-commit in pandas was that the `python-use-type-annotations` hook fails if there is a comment which starts with a word which starts with "type" (e.g. "types")