### PR TITLE
Allowed rst checks on text files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -52,7 +52,7 @@
     description: 'Detect common mistake of using single backticks when writing rst'
     entry: '(^| )`[^`]+`([^_]|$)'
     language: pygrep
-    types: [rst]
+    types: [text]
 -   id: rst-directive-colons
     name: rst directives end with two colons
     description: 'Detect mistake of rst directive not ending with double colon'
@@ -64,7 +64,7 @@
     description: 'Detect mistake of inline code touching normal text in rst'
     entry: '\w``\w'
     language: pygrep
-    types: [rst]
+    types: [text]
 -   id: text-unicode-replacement-char
     name: no unicode replacement chars
     description: 'Forbid files which have a UTF-8 Unicode replacement character'


### PR DESCRIPTION
I'm looking at adding some pre-commit hooks to Django. The restructured text checks would be helpful to the project; however, the docs are written in `.txt` rather than `.rst` files. Therefore currently only one of these checks works for Django. 

Could the `types` be relaxed a little here? 

*Before*
```
rst ``code`` is two backticks............................................Failed
- hook id: rst-backticks
- exit code: 1

test.rst:1:a `failing` file:

rst directives end with two colons.......................................Failed
- hook id: rst-directive-colons
- exit code: 1

test.rst:6:.. versionadded:
test.txt:6:.. versionadded:
```

*After*
```
rst ``code`` is two backticks............................................Failed
- hook id: rst-backticks
- exit code: 1

test.rst:1:a `failing` file:
test.txt:1:a `failing` file:

rst directives end with two colons.......................................Failed
- hook id: rst-directive-colons
- exit code: 1

test.rst:6:.. versionadded:
test.txt:6:.. versionadded:
```