### PR TITLE
rst hooks: ignore code blocks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -50,7 +50,7 @@
 -   id: rst-backticks
     name: rst ``code`` is two backticks
     description: 'Detect common mistake of using single backticks when writing rst'
-    entry: '(^| )`[^`]+`([^_]|$)'
+    entry: '^(?!    ).*(^| )`[^`]+`([^_]|$)'
     language: pygrep
     types: [rst]
 -   id: rst-directive-colons

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -133,6 +133,8 @@ def test_python_no_log_warn_negative(s):
         'i like `_`',
         '`a`',
         '`cd`',
+        ' `indented` literal block',
+        '> quoted `literal` block',
     ),
 )
 def test_python_rst_backticks_positive(s):
@@ -147,6 +149,7 @@ def test_python_rst_backticks_positive(s):
         'i like `kitty`_',
         '``b``',
         '``ef``',
+        '    indented `literal` block',
     ),
 )
 def test_python_rst_backticks_negative(s):


### PR DESCRIPTION
Follow on from https://github.com/pre-commit/pygrep-hooks/pull/29 and https://github.com/pre-commit/pygrep-hooks/pull/30.

We found a problem with using `rst-backticks` to lint PEPs (https://github.com/python/peps/pull/1668), code blocks containing single backticks are valid. For example, this is fine but the linter complains:

```rst
    class CompiledGenSeries:

        # This class is what the `gen_series()` generator can
        # be transformed to by a compiler like Cython.
```

These are called "literal blocks" in rst: https://docutils.sourceforge.io/docs/user/rst/quickref.html#literal-blocks

> A paragraph containing only two colons
indicates that the following indented
or quoted text is a literal block.

Where quoting is given as lines beginning `>`.

For our purposes, I think it's good enough to ignore the `::` bit and skip lines beginning with a space or `>`.

This PR prepends the regex with `^(?![ >]).*`

That is:
* start of line
* Negative lookahead for space or `>`
* Any other char

The same problem can potentially occur with `rst-inline-touching-normal`, so I added it there too.
