### PR TITLE
add check for ipython embed function

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -29,6 +29,12 @@
             )($|[^(\w])
         )
     types: [python]
+-   id: python-no-ipython-embed
+    name: check for embed()
+    description: 'A quick check for the ipython `embed()` function'
+    entry: '\bembed\('
+    language: pygrep
+    types: [python]
 -   id: python-no-eval
     name: check for eval()
     description: 'A quick check for the `eval()` built-in function'

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ For example, a hook which targets python will be called `python-...`.
 [generated]: # (generated)
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
+- **`python-no-ipython-embed`**: A quick check for the ipython `embed()` function
 - **`python-no-eval`**: A quick check for the `eval()` built-in function
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -102,6 +102,14 @@ def test_python_noeval_negative():
     assert not HOOKS['python-no-eval'].search('literal_eval("{1: 2}")')
 
 
+def test_python_no_embed_positive():
+    assert HOOKS['python-no-ipython-embed'].search('embed()')
+
+
+def test_python_no_embed_negative():
+    assert not HOOKS['python-no-ipython-embed'].search('alt_embed()')
+
+
 @pytest.mark.parametrize(
     's',
     (


### PR DESCRIPTION
The ipython `embed()` function is useful for debugging, but a major problem if accidentally left in code. This PR adds a pre-commit check to ensure it's removed.