### PR TITLE
Correct type from text to rst for rst-directive-colons hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -58,7 +58,7 @@
     description: 'Detect mistake of rst directive not ending with double colon'
     entry: '^\s*\.\. [a-z]+:$'
     language: pygrep
-    types: [text]
+    types: [rst]
 -   id: rst-inline-touching-normal
     name: rst ``inline code`` next to normal text
     description: 'Detect mistake of inline code touching normal text in rst'


### PR DESCRIPTION
Assign the correct `types` to the `rst-directive-colons` hook, ensuring it only triggers on `rst` files and categorizing it properly on the pre-commit hooks site list.

Fix #44 