### PR TITLE
Add hook to find blanket type ignores

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,12 @@
     entry: '(?i)# noqa(?!: )'
     language: pygrep
     types: [python]
+-   id: python-check-blanket-type-ignore
+    name: check blanket type ignore
+    description: 'Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`'
+    entry: '# type:? *ignore(?!\[|\w)'
+    language: pygrep
+    types: [python]
 -   id: python-check-mock-methods
     name: check for not-real mock methods
     description: >-

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For example, a hook which targets python will be called `python-...`.
 
 [generated]: # (generated)
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`
+- **`python-check-blanket-type-ignore`**: Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
 - **`python-no-eval`**: A quick check for the `eval()` built-in function
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -65,6 +65,34 @@ def test_python_check_blanket_noqa_negative(s):
 @pytest.mark.parametrize(
     's',
     (
+        'x = 1  # type: ignore',
+        'x = 1  # type ignore',
+        'x = 1  # type:ignore',
+        'x = 1  # type ignore  # noqa',
+    ),
+)
+def test_python_check_blanket_type_ignore_positive(s):
+    assert HOOKS['python-check-blanket-type-ignore'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'x = 1',
+        'x = 1  # type: ignore[attr-defined]',
+        'x = 1  # type: ignore[attr-defined, name-defined]',
+        'x = 1  # type: ignore[type-mismatch]  # noqa',
+        'x = 1  # type: Union[int, str]',
+        'x = 1  # type: ignoreme',
+    ),
+)
+def test_python_check_blanket_type_ignore_negative(s):
+    assert not HOOKS['python-check-blanket-type-ignore'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
         'assert my_mock.not_called()',
         'assert my_mock.called_once_with()',
         'my_mock.assert_not_called',


### PR DESCRIPTION
Recently I learned that mypy supports silencing specific error codes on a line rather than a blanket ignore (e.g. `# type: ignore[attr-defined]` vs. just `# type: ignore`). I'd like to be able to lint for this like I lint for blanket `# noqa`, so I've taken a stab at adding it here.

I hope I've captured all of the potentially problematic test cases but will continue to check for more!