### PR TITLE
Add an inclusive naming check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 /.mypy_cache
+.hypothesis

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 *.pyc
 /.mypy_cache
-.hypothesis

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,9 @@
+-   id: inclusive-naming-check
+    name: use inclusive naming
+    description: 'Detect non-inclusive language. See https://inclusivenaming.org/ for alternatives.'
+    entry: 'dummy|whitelist|blacklist|sanity|slave'
+    language: pygrep
+    types: [text]
 -   id: python-check-blanket-noqa
     name: check blanket noqa
     description: 'Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`'

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For example, a hook which targets python will be called `python-...`.
 ### Provided hooks
 
 [generated]: # (generated)
+- **`inclusive-naming-check`**: Detect non-inclusive language. See https://inclusivenaming.org/ for alternatives.
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`
 - **`python-check-blanket-type-ignore`**: Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -10,6 +10,20 @@ HOOKS = {h['id']: re.compile(h['entry']) for h in load_manifest(MANIFEST_FILE)}
 @pytest.mark.parametrize(
     's',
     (
+        'sanity check',
+        'dummy code',
+        'use a whitelist',
+        'a blacklisted term',
+        'a slave process',
+    ),
+)
+def test_inclusive_naming_check(s):
+    assert HOOKS['inclusive-naming-check'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
         'x = 1 # type: ignoreme',
         'x = 1  # type: int',
         'x = 1  # type int',


### PR DESCRIPTION
This feels useful! I took a few hints from the inclusive naming website, but decided to not add `master` and `abort` since those are used quite frequently. Happy to add 'em if you'd prefer to future-proof this check!