### PR TITLE
Add `python-check-blanket-nosec` hook for bandit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,12 @@
     entry: '(?i)# noqa(?!: )'
     language: pygrep
     types: [python]
+-   id: python-check-blanket-nosec
+    name: check blanket nosec
+    description: 'Enforce that bandit `nosec` annotations always occur with specific codes. Sample annotations: `# nosec: B101`, `# nosec: B101,B102`'
+    entry: '# *nosec(?!: *\w)'
+    language: pygrep
+    types: [python]
 -   id: python-check-blanket-type-ignore
     name: check blanket type ignore
     description: 'Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`'

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For example, a hook which targets python will be called `python-...`.
 
 [generated]: # (generated)
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`
+- **`python-check-blanket-nosec`**: Enforce that bandit `nosec` annotations always occur with specific codes. Sample annotations: `# nosec: B101`, `# nosec: B101,B102`
 - **`python-check-blanket-type-ignore`**: Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
 - **`python-no-eval`**: A quick check for the `eval()` built-in function

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -65,6 +65,37 @@ def test_python_check_blanket_noqa_negative(s):
 @pytest.mark.parametrize(
     's',
     (
+        'x = 1  # nosec',
+        'x = 1  # nosec:',
+        'x = 1  # nosec:     ',
+        'x = 1  # nosec  # noqa',
+    ),
+)
+def test_python_check_blanket_nosec_positive(s):
+    assert HOOKS['python-check-blanket-nosec'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'x = 1',
+        'x = 1  # nosec: B101',
+        'x = 1  # nosec: B101',
+        'x = 1  # nosec: B101,B102',
+        'x = 1  # nosec: B101, B102',
+        'x = 1  # nosec: B101 B102',
+        'x = 1  # nosec:B101 B102',
+        'x = 1  # nosec: B101, subprocess_popen_with_shell_equals_true',
+        'x = 1  # nosec: B101 subprocess_popen_with_shell_equals_true  # noqa',
+    ),
+)
+def test_python_check_blanket_nosec_negative(s):
+    assert not HOOKS['python-check-blanket-nosec'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
         'x = 1  # type: ignore',
         'x = 1  # type ignore',
         'x = 1  # type:ignore',


### PR DESCRIPTION
[Version 1.7.3](https://github.com/PyCQA/bandit/releases/tag/1.7.3) of Python SAST tool [bandit](https://github.com/PyCQA/bandit) added support for disabling individual tests in https://github.com/PyCQA/bandit/pull/597.

It is now possible to disable specific codes like so:
```python
# nosec: B101, B102
# nosec: B101 subprocess_popen_with_shell_equals_true
```

I thought that this could be a nice thing to have in this project.