### PR TITLE
feat(eval): allow .eval() methods

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -38,7 +38,7 @@
 -   id: python-no-eval
     name: check for eval()
     description: 'A quick check for the `eval()` built-in function'
-    entry: '\beval\('
+    entry: '(?<!\.)\beval\('
     language: pygrep
     types: [python]
 -   id: python-no-log-warn

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -130,6 +130,7 @@ def test_python_noeval_positive():
 
 def test_python_noeval_negative():
     assert not HOOKS['python-no-eval'].search('literal_eval("{1: 2}")')
+    assert not HOOKS['python-no-eval'].search('foo.eval()')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
`eval()` is evil, but `foo.eval()` probably just means you're using
pytorch:

https://github.com/pytorch/pytorch/blob/1c5a8125798392f8d7c57e88735f43a14ae0beca/torch/nn/modules/module.py#L1799

Fixes pre-commit/pygrep-hooks#91