### PR TITLE
Add check for print function

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -47,6 +47,12 @@
     entry: '(?<!warnings)\.warn\('
     language: pygrep
     types: [python]
+-   id: python-no-print
+    name: check for print()
+    description: 'A quick check for the `print()` built-in function'
+    entry: '\bprint\('
+    language: pygrep
+    types: [python]
 -   id: python-use-type-annotations
     name: type annotations not comments
     description: 'Enforce that python3.6+ type annotations are used instead of type comments'

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For example, a hook which targets python will be called `python-...`.
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
 - **`python-no-eval`**: A quick check for the `eval()` built-in function
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
+- **`python-no-print`**: A quick check for the `print()` built-in function
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments
 - **`rst-backticks`**: Detect common mistake of using single backticks when writing rst
 - **`rst-directive-colons`**: Detect mistake of rst directive not ending with double colon

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -158,6 +158,28 @@ def test_python_no_log_warn_negative(s):
 @pytest.mark.parametrize(
     's',
     (
+        'print("3 + 4")',
+        'print(var, end="")',
+    ),
+)
+def test_python_no_print_positive(s):
+    assert HOOKS['python-no-print'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'logging.log("print")',
+        'foo_print("{1: 2}")',
+    ),
+)
+def test_python_no_print_negative(s):
+    assert not HOOKS['python-no-print'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
         '`[code]`',
         'i like `_kitty`',
         'i like `_`',


### PR DESCRIPTION
I often use print for debugging purposes, but I do not want those to be committed, as they would clutter the logs and may be explicit when a bug is really hard to find 😅 

From the pre-commit hooks repo I already have in my projects, yours seemed the best to add this check, thank you for your work!