### PR TITLE
python-no-calls-to-debugger

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -35,6 +35,12 @@
             )($|[^(\w])
         )
     types: [python]
+-   id: python-no-calls-to-debugger
+    name: no calls to debugger in commited code
+    description: 'Forbids `set_trace()` or `breakpoint()` calls'
+    entry: 'breakpoint\(\)|set_trace\(\)'
+    language: pygrep
+    types: [python]
 -   id: python-no-eval
     name: check for eval()
     description: 'A quick check for the `eval()` built-in function'

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For example, a hook which targets python will be called `python-...`.
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`
 - **`python-check-blanket-type-ignore`**: Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
+- **`python-no-calls-to-debugger`**: simple check for `set_trace()` or `breakpoint()` calls
 - **`python-no-eval`**: A quick check for the `eval()` built-in function
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For example, a hook which targets python will be called `python-...`.
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`
 - **`python-check-blanket-type-ignore`**: Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
-- **`python-no-calls-to-debugger`**: simple check for `set_trace()` or `breakpoint()` calls
+- **`python-no-calls-to-debugger`**: Forbids `set_trace()` or `breakpoint()` calls
 - **`python-no-eval`**: A quick check for the `eval()` built-in function
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -233,6 +233,16 @@ def test_python_rst_inline_touching_normal_negative(s):
 def test_text_unicode_replacement_char_positive(s):
     assert HOOKS['text-unicode-replacement-char'].search(s)
 
+@pytest.mark.parametrize(
+    's',
+    (
+        "set_trace()",
+        "breakpoint()"
+    ),
+)
+def test_python_no_calls_to_debugger(s):
+    assert HOOKS['python-no-calls-to-debugger'].search(s)
+
 
 @pytest.mark.parametrize(
     's',

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -233,11 +233,12 @@ def test_python_rst_inline_touching_normal_negative(s):
 def test_text_unicode_replacement_char_positive(s):
     assert HOOKS['text-unicode-replacement-char'].search(s)
 
+
 @pytest.mark.parametrize(
     's',
     (
-        "set_trace()",
-        "breakpoint()"
+        'set_trace()',
+        'breakpoint()',
     ),
 )
 def test_python_no_calls_to_debugger(s):


### PR DESCRIPTION
Simple check for no calls to `breakpoint()` or `set_trace()` in Python code. 

This prevents accidental committing of code that runs debugger. Then the CI waits for the debugger to finish or timeout which is usually about 30 minutes or so. 