### PR TITLE
Add `rst-directive-space` check

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -61,8 +61,8 @@
     types: [rst]
 -   id: rst-directive-colons
     name: rst directives end with two colons
-    description: 'Detect mistake of rst directive not ending with double colon'
-    entry: '^\s*\.\. [a-z]+:$'
+    description: 'Detect mistake of rst directive not ending with double colon or space before the double colon'
+    entry: '^\s*\.\. [a-z]+(| | :):$'
     language: pygrep
     types: [rst]
 -   id: rst-inline-touching-normal

--- a/README.md
+++ b/README.md
@@ -31,6 +31,6 @@ For example, a hook which targets python will be called `python-...`.
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments
 - **`rst-backticks`**: Detect common mistake of using single backticks when writing rst
-- **`rst-directive-colons`**: Detect mistake of rst directive not ending with double colon
+- **`rst-directive-colons`**: Detect mistake of rst directive not ending with double colon or space before the double colon
 - **`rst-inline-touching-normal`**: Detect mistake of inline code touching normal text in rst
 - **`text-unicode-replacement-char`**: Forbid files which have a UTF-8 Unicode replacement character

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -249,6 +249,10 @@ def test_text_unicode_replacement_char_negative(s):
     (
         '    .. warning:',
         '.. warning:',
+        '    .. warning ::',
+        '.. warning ::',
+        '    .. warning :',
+        '.. warning :',
     ),
 )
 def test_rst_directive_colons_positive(s):


### PR DESCRIPTION
Another reasonably common mistake, e.g. https://github.com/matplotlib/matplotlib/pull/24927 is to put a space before the double colon.

Ideally one should check for the combination of space and single colon, but not clear if it is better to merge this check with a more complicated regex for test-directive-colons or modify this to check for both (or keep it as is).

(Also, this will not catch https://github.com/matplotlib/matplotlib/pull/24927 as it is in a py and a c++-file, but for consistency with the other rst-tests...)