### PR TITLE
Allow spaces before specific type ignore error codes

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -7,7 +7,7 @@
 -   id: python-check-blanket-type-ignore
     name: check blanket type ignore
     description: 'Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`'
-    entry: '# type:? *ignore(?!\[|\w)'
+    entry: '# type:? *ignore(?! *\[|\w)'
     language: pygrep
     types: [python]
 -   id: python-check-mock-methods

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -82,6 +82,7 @@ def test_python_check_blanket_type_ignore_positive(s):
     (
         'x = 1',
         'x = 1  # type: ignore[attr-defined]',
+        'x = 1  # type: ignore [attr-defined]',
         'x = 1  # type: ignore[attr-defined, name-defined]',
         'x = 1  # type: ignore[type-mismatch]  # noqa',
         'x = 1  # type: Union[int, str]',


### PR DESCRIPTION
The `python-check-blanket-type-ignore` hook catches

    # type: ignore [assignment]

as a blanket type ignore, which it is not.

This allows spaces before the specific error type so these comments do not cause the hook to fail.

Fixes #142