### PR TITLE
fix(python-use-type-annotations): alter regex for python-use-type-annotations

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -50,7 +50,7 @@
 -   id: python-use-type-annotations
     name: type annotations not comments
     description: 'Enforce that python3.6+ type annotations are used instead of type comments'
-    entry: '# type(?!: *ignore([^a-zA-Z0-9]|$))'
+    entry: '# type[ :](?! *ignore([^a-zA-Z0-9]|$))'
     language: pygrep
     types: [python]
 -   id: rst-backticks

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -29,10 +29,12 @@ def test_python_use_type_annotations_positive(s):
         'x = 1  # type:ignore',
         'x = 1  # type: ignore',
         'x = 1  # type:  ignore',
+        'x = 1  # type:  ignore    ',
         'x = 1  # type: ignore # noqa',
         'x = 1  # type: ignore  # noqa',
         'x = 1  # type: ignore[type-mismatch]',
         'x = 1  # type: ignore=E123',
+        'x = 1  # types of integers are ok',
     ),
 )
 def test_python_use_type_annotations_negative(s):


### PR DESCRIPTION
Hi there :wave: 

I was just trying to set up the `python-use-type-annotations` hook on a project and it threw a few false positives for me.

I have a line of code that reads:

```python
# types with long names in changelog
```

Of course unrelated to type-annotations. I've adjusted the pattern and added a couple of test cases (looked like one with trailing whitespace was missing). It's probably a niche edge-case but it was also a quick change :man_shrugging:

Thanks for the awesome set of hooks! :rocket: