### PR TITLE
Add checks for debugging breakpoint functions

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -35,6 +35,12 @@
             )($|[^(\w])
         )
     types: [python]
+-   id: python-no-breakpoint
+    name: check for breakpoint()
+    description: 'A quick check for the `breakpoint()` built-in function'
+    entry: '\bbreakpoint\('
+    language: pygrep
+    types: [python]
 -   id: python-no-eval
     name: check for eval()
     description: 'A quick check for the `eval()` built-in function'
@@ -45,6 +51,12 @@
     name: use logger.warning(
     description: 'A quick check for the deprecated `.warn()` method of python loggers'
     entry: '(?<!warnings)\.warn\('
+    language: pygrep
+    types: [python]
+-   id: python-no-pdb-set-trace
+    name: check for pdb.set_trace()
+    description: 'A quick check for the `pdb.set_trace()` function'
+    entry: '\bpdb\.set_trace\('
     language: pygrep
     types: [python]
 -   id: python-use-type-annotations

--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ For example, a hook which targets python will be called `python-...`.
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`
 - **`python-check-blanket-type-ignore`**: Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
+- **`python-no-breakpoint`**: A quick check for the `breakpoint()` built-in function
 - **`python-no-eval`**: A quick check for the `eval()` built-in function
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
+- **`python-no-pdb-set-trace`**: A quick check for the `pdb.set_trace()` function
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments
 - **`rst-backticks`**: Detect common mistake of using single backticks when writing rst
 - **`rst-directive-colons`**: Detect mistake of rst directive not ending with double colon or space before the double colon

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -124,12 +124,28 @@ def test_python_check_mock_methods_negative(s):
     assert not HOOKS['python-check-mock-methods'].search(s)
 
 
+def test_python_nobreakpoint_positive():
+    assert HOOKS['python-no-breakpoint'].search('breakpoint()')
+
+
+def test_python_nobreakpoint_negative():
+    assert not HOOKS['python-no-breakpoint'].search('set_breakpoint()')
+
+
 def test_python_noeval_positive():
     assert HOOKS['python-no-eval'].search('eval("3 + 4")')
 
 
 def test_python_noeval_negative():
     assert not HOOKS['python-no-eval'].search('literal_eval("{1: 2}")')
+
+
+def test_python_no_pdb_set_trace_positive():
+    assert HOOKS['python-no-pdb-set-trace'].search('pdb.set_trace()')
+
+
+def test_python_no_pdb_set_trace_negative():
+    assert not HOOKS['python-no-pdb-set-trace'].search('mypdb.set_trace()')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Add checks for calls to pdb.set_trace() and breakpoint(), which are often accidentally left in code but should not be deployed to production