### PR TITLE
Add check for lstrip/rstrip using a literal string -

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -50,7 +50,7 @@
 -   id: python-no-lstrip-rstrip-with-literal-str
     name: check for lstrip or rstrip calls with literal string
     description: 'A quick check for lstrip or rstrip calls that should use removeprefix or removesuffix'
-    entry: '\.[lr]strip\("\S'
+    entry: '\.[lr]strip\(["'']\S'
     language: pygrep
     types: [python]
 -   id: python-use-type-annotations

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -49,7 +49,7 @@
     types: [python]
 -   id: python-no-lstrip-rstrip-with-literal-str
     name: check for lstrip or rstrip calls with literal string
-    description: 'A quick check for lstrip or rstrip calls that should use removeprefix or removesuffix'
+    description: 'A quick check for `str.lstrip()` or `str.rstrip()` calls that should probably use `str.removeprefix()` or `str.removesuffix()`'
     entry: '\.[lr]strip\(["'']\S'
     language: pygrep
     types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -47,6 +47,12 @@
     entry: '(?<!warnings)\.warn\('
     language: pygrep
     types: [python]
+-   id: python-no-lstrip-rstrip-with-literal-str
+    name: check for lstrip or rstrip calls with literal string
+    description: 'A quick check for lstrip or rstrip calls that should use removeprefix or removesuffix'
+    entry: '\.[lr]strip\("\S'
+    language: pygrep
+    types: [python]
 -   id: python-use-type-annotations
     name: type annotations not comments
     description: 'Enforce that python3.6+ type annotations are used instead of type comments'

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For example, a hook which targets python will be called `python-...`.
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
 - **`python-no-eval`**: A quick check for the `eval()` built-in function
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
-- **`python-no-lstrip-rstrip-with-literal-str`**: A quick check for lstrip or rstrip calls that should use removeprefix or removesuffix
+- **`python-no-lstrip-rstrip-with-literal-str`**: A quick check for `str.lstrip()` or `str.rstrip()` calls that should probably use `str.removeprefix()` or `str.removesuffix()`
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments
 - **`rst-backticks`**: Detect common mistake of using single backticks when writing rst
 - **`rst-directive-colons`**: Detect mistake of rst directive not ending with double colon or space before the double colon

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For example, a hook which targets python will be called `python-...`.
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
 - **`python-no-eval`**: A quick check for the `eval()` built-in function
 - **`python-no-log-warn`**: A quick check for the deprecated `.warn()` method of python loggers
+- **`python-no-lstrip-rstrip-with-literal-str`**: A quick check for lstrip or rstrip calls that should be removeprefix or removesuffix
 - **`python-use-type-annotations`**: Enforce that python3.6+ type annotations are used instead of type comments
 - **`rst-backticks`**: Detect common mistake of using single backticks when writing rst
 - **`rst-directive-colons`**: Detect mistake of rst directive not ending with double colon or space before the double colon

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -158,6 +158,33 @@ def test_python_no_log_warn_negative(s):
 @pytest.mark.parametrize(
     's',
     (
+        'my_url.lstrip("http://")',
+        'filename.rstrip(".html")',
+        's.lstrip("ABC")',
+        's.rstrip("ABC")',
+    ),
+)
+def test_python_no_lstrip_positive(s):
+    assert HOOKS['python-no-lstrip-rstrip-with-literal-str'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'csv_field.lstrip()',
+        'line.rstrip()',
+        'line.rstrip("\n")',
+        's.allstrip("ABC")',
+        's.farstrip("ABC")',
+    ),
+)
+def test_python_no_lstrip_negative(s):
+    assert not HOOKS['python-no-lstrip-rstrip-with-literal-str'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
         '`[code]`',
         'i like `_kitty`',
         'i like `_`',

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -162,6 +162,8 @@ def test_python_no_log_warn_negative(s):
         'filename.rstrip(".html")',
         's.lstrip("ABC")',
         's.rstrip("ABC")',
+        "s.lstrip('ABC')",
+        "s.rstrip('ABC')",
     ),
 )
 def test_python_no_lstrip_positive(s):
@@ -176,6 +178,8 @@ def test_python_no_lstrip_positive(s):
         'line.rstrip("\n")',
         's.allstrip("ABC")',
         's.farstrip("ABC")',
+        "s.allstrip('ABC')",
+        "s.farstrip('ABC')",
     ),
 )
 def test_python_no_lstrip_negative(s):


### PR DESCRIPTION
 when the string contains non-whitespace characters, this is often a bug, and should use removeprefix or removesuffix instead

    s = "url://lucy.com"
    host = s.lstrip("url://")  # bug, yields "cy.com"
    host = s.removeprefix("url://")  # correct