### PR TITLE
add python-check-blanket-nosec

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,12 @@
     entry: '(?i)# noqa(?!: )'
     language: pygrep
     types: [python]
+-   id: python-check-blanket-nosec
+    name: check blanket nosec
+    description: 'Enforce that `nosec` annotations always occur with specific codes. Sample annotations: `# nosec assert_used`, `# nosec B602, B607`'
+    entry: '(?i)#\s*nosec:?\s*(?![^#])'
+    language: pygrep
+    types: [python]
 -   id: python-check-blanket-type-ignore
     name: check blanket type ignore
     description: 'Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`'

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ For example, a hook which targets python will be called `python-...`.
 
 [generated]: # (generated)
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`
+- **`python-check-blanket-nosec`**: Enforce that `nosec` annotations always occur with specific codes. Sample annotations: `# nosec assert_used`, `# nosec B602, B607`
 - **`python-check-blanket-type-ignore`**: Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.
 - **`python-no-eval`**: A quick check for the `eval()` built-in function

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -42,6 +42,34 @@ def test_python_use_type_annotations_negative(s):
 @pytest.mark.parametrize(
     's',
     (
+        '# nosec',
+        '# NOSEC',
+        '# nosec: ',
+        '# nosec ',
+    ),
+)
+def test_python_check_blanket_nosec_positive(s):
+    assert HOOKS['python-check-blanket-nosec'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'x = 1',
+        '# nosec:B401',
+        '# nosec:B401',
+        '# nosec:B401,B203',
+        '# nosec: B401',
+        '# nosec: B401, B203',
+    ),
+)
+def test_python_check_blanket_nosec_negative(s):
+    assert not HOOKS['python-check-blanket-nosec'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
         '# noqa',
         '# NOQA',
         '# noqa:F401',


### PR DESCRIPTION
modeled after `python-check-blanket-noqa` this change adds a hook to disallow blanket `# nosec` comments used by Bandit.  Regex was modeled after [bandit's own regex](https://github.com/PyCQA/bandit/blob/6d1d11c01e7824c04cc5005b4fe6b932c6999b18/bandit/core/manager.py#L27)

- [X] ran `./generate-readme`
- [X] added new tests
- [X] all tests pass