### PR TITLE
Add django-no-redundant-queryset-all hook.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,10 @@
+-   id: django-no-redundant-queryset-all
+    name: no redundant calls to queryset.all()
+    description: Check for redundant calls to the queryset `all()` method
+    entry: all\(\s*\)\.(count|filter|exclude|update)\(
+    language: pygrep
+    args: [--multiline]
+    types: [python]
 -   id: python-check-blanket-noqa
     name: check blanket noqa
     description: 'Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`'

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For example, a hook which targets python will be called `python-...`.
 ### Provided hooks
 
 [generated]: # (generated)
+- **`django-no-redundant-queryset-all`**: Check for redundant calls to the queryset `all()` method
 - **`python-check-blanket-noqa`**: Enforce that `noqa` annotations always occur with specific codes. Sample annotations: `# noqa: F401`, `# noqa: F401,W203`
 - **`python-check-blanket-type-ignore`**: Enforce that `# type: ignore` annotations always occur with specific codes. Sample annotations: `# type: ignore[attr-defined]`, `# type: ignore[attr-defined, name-defined]`
 - **`python-check-mock-methods`**: Prevent common mistakes of `assert mck.not_called()`, `assert mck.called_once_with(...)` and `mck.assert_called`.

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -270,5 +270,28 @@ def test_rst_directive_colons_negative(s):
     assert not HOOKS['rst-directive-colons'].search(s)
 
 
+@pytest.mark.parametrize(
+    's',
+    (
+        'qs.all().count()',
+        'qs.all().filter(thing=True)',
+        'qs.all().exclude(thing=True)',
+        'qs.all().update(thing=True)',
+    ),
+)
+def test_django_no_redundant_queryset_all_positive(s):
+    assert HOOKS['django-no-redundant-queryset-all'].search(s)
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        'qs.all().some_custom_thing()',
+    ),
+)
+def test_django_no_redundant_queryset_all_negative(s):
+    assert not HOOKS['django-no-redundant-queryset-all'].search(s)
+
+
 def test_that_hooks_are_sorted():
     assert list(HOOKS) == sorted(HOOKS)


### PR DESCRIPTION
As I put this together I realised that this was almost certainly a bit too niche for this project, but as I was already halfway though I figured I'd follow through just in case Django developers are considered a major group of pre-commit users.

Anyway, this picks up on [the calling all() before count() or filter() etc. anti-pattern](https://www.django-antipatterns.com/antipattern/calling-all-before-count-or-filter.html), something I do in my work all the time.

If you agree that this is too niche for this project and I end up with a few similar hooks, I might start my own Django-flavoured version based on your work if that's alright?