### PR TITLE
Add missing closing parenthesis to `python-no-log-warn`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -42,7 +42,7 @@
     language: pygrep
     types: [python]
 -   id: python-no-log-warn
-    name: use logger.warning(
+    name: use logger.warning()
     description: 'A quick check for the deprecated `.warn()` method of python loggers'
     entry: '(?<!warnings)\.warn\('
     language: pygrep


### PR DESCRIPTION
Closes https://github.com/pre-commit/pygrep-hooks/issues/190